### PR TITLE
Add Ubuntu based test for github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,22 @@ jobs:
     - uses: actions/checkout@v3.0.1
     - name: Run build
       run: nix-build --no-out-link .
+    - name: Create artifact
+      run: cp $(nix-build --no-out-link . -A deb) nix-multi-user.deb
+    - uses: actions/upload-artifact@v3
+      with:
+        name: nix-multi-user.deb
+        path: nix-multi-user.deb
+
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: nix-multi-user.deb
+        path: nix-multi-user.deb
+    - name: Install Nix
+      run: sudo dpkg -i nix-multi-user.deb/nix-multi-user.deb
+    - name: Run nix-shell
+      run: bash -l -c "nix-shell -p hello --run hello"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
       with:
         name: nix-multi-user.deb
         path: nix-multi-user.deb
+        retention-days: 1
 
   test:
     needs: build


### PR DESCRIPTION
The only supported distro on Github Actions is Ubuntu..
While I would like to test more than this it's better than nothing.

We could potentially spin up some VMs to test other distributions but that's a lot more effort.