### PR TITLE
Add rpm-ostree support 

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -169,10 +169,11 @@ let
       cp -a ${./rootfs} rootfs
       find rootfs -type f | xargs chmod 644
       find rootfs -type d | xargs chmod 755
-      mkdir -p rootfs/usr/share/nix
+
       cp ${tarball} rootfs/usr/share/nix/nix.tar.xz
 
       chmod +x rootfs/etc/profile.d/nix-env.sh
+      chmod +x rootfs/usr/share/nix/nix-setup
 
       mkdir -p rootfs/usr/share/selinux/packages
       cp ${selinux}/nix.pp rootfs/usr/share/selinux/packages/
@@ -206,6 +207,6 @@ in
 
   pacman = buildLegacyPkg { type = "pacman"; };
 
-  rpm = buildLegacyPkg { type = "rpm"; };
+  rpm = buildLegacyPkg { type = "rpm"; channel = null; };
 
 }

--- a/hooks/after-install.sh
+++ b/hooks/after-install.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 NIX_BUILD_GROUP_ID="30000"
 NIX_BUILD_GROUP_NAME="nixbld"
@@ -24,35 +25,10 @@ for i in $(seq 1 $(($cores>32 ? $cores : 32))); do
       "$username"
 done
 
-# Create /nix/store if a fresh install, otherwise leave in place
-if ! test -e /nix/var/nix/db; then
-    tar -xpf /usr/share/nix/nix.tar.xz
-    rm -f /usr/share/nix/nix.tar.xz
-fi
-
-# Inspired by https://github.com/NixOS/nix/pull/2670
 if test -e /sys/fs/selinux; then
-    # Install the Nix SELinux policy
     semodule -i "/usr/share/selinux/packages/nix.pp"
-
-    # Relabel the SELinux security context
-    restorecon -FR /nix
-
-    # Reexec systemd (is this really required?)
-    systemctl daemon-reexec
 fi
 
-if ! test -e /root/.nix-defexpr && test -e /nix/var/nix/profiles/per-user/root/channels; then
-    mkdir -p $out/root/.nix-defexpr
-    ln -s /nix/var/nix/profiles/per-user/root/channels /root/.nix-defexpr/channels
-fi
-if ! [[ "@channelURL@" = "" || "@channelName@" = "" ]] && ! test -e /root/.nix-channels; then
-    echo "@channelURL@ @channelName@" > /root/.nix-channels
-fi
-
-# Enable autostart
 systemctl enable nix-daemon
-systemctl start nix-daemon
 
-# Make shell script exit with success regardless of systemd units failing to start immediately
-true
+systemctl start nix-daemon || true

--- a/hooks/after-remove.sh
+++ b/hooks/after-remove.sh
@@ -4,4 +4,4 @@ grep '^nixbld' /etc/passwd | cut -d : -f 1 | while read user; do
     userdel "$user"
 done
 groupdel nixbld
-rm -rf /nix
+rm -rf /var/nix

--- a/rootfs/usr/lib/systemd/system/mkdir-rootfs@.service
+++ b/rootfs/usr/lib/systemd/system/mkdir-rootfs@.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Enable mount points in / for ostree
+DefaultDependencies=no
+ConditionPathExists=!%f
+
+[Service]
+Type=oneshot
+ExecStartPre=chattr -i /
+ExecStart=mkdir -p '%f'
+ExecStopPost=chattr +i /

--- a/rootfs/usr/lib/systemd/system/nix-setup.service
+++ b/rootfs/usr/lib/systemd/system/nix-setup.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Nix store setup
+Before=nix.mount
+
+[Service]
+ExecStart=/usr/share/nix/nix-setup
+Type=oneshot

--- a/rootfs/usr/lib/systemd/system/nix.mount
+++ b/rootfs/usr/lib/systemd/system/nix.mount
@@ -1,0 +1,12 @@
+[Unit]
+After=mkdir-rootfs@nix.service nix-setup.service
+Wants=mkdir-rootfs@nix.service nix-setup.service
+
+[Mount]
+What=/var/nix
+Where=/nix
+Options=bind
+Type=none
+
+[Install]
+WantedBy=local-fs.target

--- a/rootfs/usr/share/nix/nix-setup
+++ b/rootfs/usr/share/nix/nix-setup
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if test -e /var/nix/store; then
+    exit 0
+fi
+
+# Create the stoure
+mkdir -p /var
+tar -C /var -xpf /usr/share/nix/nix.tar.xz
+rm -f /usr/share/nix/nix.tar.xz || true
+
+# Set up root channels ()
+if ! test -e /root/.nix-defexpr && test -e /nix/var/nix/profiles/per-user/root/channels; then
+    mkdir -p $out/root/.nix-defexpr
+    ln -s /nix/var/nix/profiles/per-user/root/channels /root/.nix-defexpr/channels
+fi
+if ! [[ "@channelURL@" = "" || "@channelName@" = "" ]] && ! test -e /root/.nix-channels; then
+    echo "@channelURL@ @channelName@" > /root/.nix-channels
+fi
+
+if test -e /sys/fs/selinux; then
+    semodule -i "/usr/share/selinux/packages/nix.pp"
+
+    # # Relabel the SELinux security context
+    # restorecon -FR /nix
+fi


### PR DESCRIPTION
Currently not working:
- [ ] I broke non-ostree setups with the whole `chattr` dance
- [ ] Fix auto-startup (currently broken)

Current steps to run nix on an rpm-ostree distro:
- `rpm-ostree install foo.rpm`
- `systemctl reboot`
- `systemctl start nix-daemon` <- Fails because it's lacking correct SELinux labels
- `restorecon -FR /nix`
- `systemctl start nix-daemon`