### PR TITLE
Support systems with older versions of SELinux

### DIFF
--- a/hooks/after-install.sh
+++ b/hooks/after-install.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 NIX_BUILD_GROUP_ID="30000"
 NIX_BUILD_GROUP_NAME="nixbld"
 
@@ -52,7 +54,5 @@ fi
 
 # Enable autostart
 systemctl enable nix-daemon
-systemctl start nix-daemon
-
 # Make shell script exit with success regardless of systemd units failing to start immediately
-true
+systemctl start nix-daemon || true

--- a/selinux/Makefile
+++ b/selinux/Makefile
@@ -1,6 +1,6 @@
 # Policies taken from https://github.com/NixOS/nix/pull/2670
 all:
-	checkmodule -M -m -o nix.mod nix.te
+	checkmodule -M -m -c 5 -o nix.mod nix.te
 	semodule_package -o nix.pp -m nix.mod -f nix.fc
 
 clean:


### PR DESCRIPTION
This builds the SELinux policy package with an older version of the module representation so that the package can be installed on systems with versions of SELinux older than the one in nixpkgs. I used the oldest version that successfully built.

I've included the addition of `set -e` to the install hook, but I'm happy to remove that commit if you don't want it.

Fixes: #9