### PR TITLE
feat: enable graphical app icons in desktops

### DIFF
--- a/rootfs/usr/lib/environment.d/nix-daemon.conf
+++ b/rootfs/usr/lib/environment.d/nix-daemon.conf
@@ -1,2 +1,3 @@
 NIX_REMOTE=daemon
 PATH="$HOME/.nix-profile/bin:/nix/var/nix/profiles/system/bin:/nix/var/nix/profiles/default/bin:$PATH"
+XDG_DATA_DIRS=$HOME/.nix-profile/share:"${XDG_DATA_DIRS:-/usr/local/share/:/usr/share/}"


### PR DESCRIPTION
Following https://unix.stackexchange.com/a/311645/50281 we add `$XDG_DATA_DIRS` to let users install and use nix GUI apps in other distros, out of the box.

@moduon MT-845