### PR TITLE
refactor: don't create nixbld group and users

### DIFF
--- a/.github/pages.py
+++ b/.github/pages.py
@@ -49,7 +49,6 @@ def main(
             found = True
 
             for fmt, arches in installers.items():
-
                 md.append(f"- {fmt.capitalize()}")
 
                 for arch, pkg in arches.items():

--- a/default.nix
+++ b/default.nix
@@ -196,7 +196,6 @@ let
         --name ${pname} \
         --version ${nix.version} \
         --after-install ${pkgs.substituteAll { src = ./hooks/after-install.sh; inherit channelName channelURL; }} \
-        --after-remove ${./hooks/after-remove.sh} \
         -C rootfs \
         .
 

--- a/hooks/after-install.sh
+++ b/hooks/after-install.sh
@@ -2,30 +2,6 @@
 
 set -e
 
-NIX_BUILD_GROUP_ID="30000"
-NIX_BUILD_GROUP_NAME="nixbld"
-
-# Setup group
-groupadd -g "$NIX_BUILD_GROUP_ID" --system "$NIX_BUILD_GROUP_NAME"
-
-# Add build users (same as number of cores on the machine to scale with `max-jobs = auto`)
-cores=$(nproc)
-for i in $(seq 1 $(($cores>32 ? $cores : 32))); do
-    username="nixbld$i"
-    uid=$((30000 + i))
-    useradd \
-      --home-dir /var/empty \
-      --comment "Nix build user $i" \
-      --gid "$NIX_BUILD_GROUP_ID" \
-      --groups "$NIX_BUILD_GROUP_NAME" \
-      --no-user-group \
-      --system \
-      --shell /sbin/nologin \
-      --uid "$uid" \
-      --password "!" \
-      "$username"
-done
-
 # Create /nix/store if a fresh install, otherwise leave in place
 if ! test -e /nix/var/nix/db; then
     tar -xpf /usr/share/nix/nix.tar.xz

--- a/hooks/after-remove.sh
+++ b/hooks/after-remove.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-grep '^nixbld' /etc/passwd | cut -d : -f 1 | while read user; do
-    userdel "$user"
-done
-groupdel nixbld
-rm -rf /nix

--- a/rootfs/etc/nix/nix.conf
+++ b/rootfs/etc/nix/nix.conf
@@ -1,6 +1,5 @@
-build-users-group = nixbld
-
 # Auto-scale builders
+auto-allocate-uids = true
 max-jobs = auto
 cores = 0
 
@@ -33,4 +32,4 @@ keep-outputs = true
 keep-derivations = true
 
 # Enable required features
-experimental-features = nix-command flakes
+experimental-features = auto-allocate-uids nix-command flakes


### PR DESCRIPTION
Since 602cbb88220aa702ebd87e4771ddd2a624b8df46, we're shipping Nix 2.13.

[Nix 2.12 is now able to work in multi-user mode without nixbld users](https://discourse.nixos.org/t/nix-2-12-0-released/23780).

Thus, all this part of the code can be removed. Instead, the new `auto-allocate-uids` experimental feature is enabled. It works fine, according to my tests.

Fixes https://github.com/nix-community/nix-installers/issues/16.